### PR TITLE
Add support for html hyperlinks

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
 		"preact-i18nline": "^2.0.0",
 		"preact-router": "^2.5.7",
 		"query-string": "6.8.3",
+		"sanitize-html": "^1.27.2",
 		"tiny-events": "^1.0.1",
 		"wolfy87-eventemitter": "^5.2.5"
 	},

--- a/src/components/Composer/index.js
+++ b/src/components/Composer/index.js
@@ -24,6 +24,7 @@ const parse = (plainText) =>
 	[{ plain: plainText }]
 		.map(({ plain, html }) => (plain ? escapeHtml(plain) : html || ''))
 		.join('');
+
 const findLastTextNode = (node) => {
 	if (node.nodeType === Node.TEXT_NODE) {
 		return node;
@@ -93,7 +94,7 @@ export class Composer extends Component {
 			items.filter((item) => item.kind === 'string' && /^text\/plain/.test(item.type))
 				.map((item) => new Promise((resolve) => item.getAsString(resolve))),
 		);
-		texts.forEach((text) => this.pasteText(text));
+		texts.forEach((text) => this.pasteText(parse(text)));
 	}
 
 	handleDrop = (onUpload) => async (event) => {
@@ -116,7 +117,7 @@ export class Composer extends Component {
 			items.filter((item) => item.kind === 'string' && /^text\/plain/.test(item.type))
 				.map((item) => new Promise((resolve) => item.getAsString(resolve))),
 		);
-		texts.forEach((text) => this.pasteText(text));
+		texts.forEach((text) => this.pasteText(parse(text)));
 	}
 
 	handleClick = () => {

--- a/src/components/Messages/MessageText/index.js
+++ b/src/components/Messages/MessageText/index.js
@@ -3,6 +3,16 @@ import { renderMarkdown } from './markdown';
 import styles from './styles.scss';
 import renderEmojis from './emoji';
 
+const sanitizeHtml = require('sanitize-html');
+
+const sanitizeHtmlOptions = {
+	allowedTags: ['a'],
+	allowedAttributes: {
+		a: ['href', 'name', 'target'],
+	},
+};
+
+
 export const MessageText = memo(({
 	text,
 	system,
@@ -11,7 +21,7 @@ export const MessageText = memo(({
 }) => (
 	<div
 		// eslint-disable-next-line react/no-danger
-		dangerouslySetInnerHTML={{ __html: renderEmojis(renderMarkdown(text), text) }}
+		dangerouslySetInnerHTML={{ __html: renderEmojis(renderMarkdown(sanitizeHtml(text, sanitizeHtmlOptions)), text) }}
 		className={createClassName(styles, 'message-text', { system }, [className])}
 		style={style}
 	/>

--- a/src/components/Messages/MessageText/markdown.js
+++ b/src/components/Messages/MessageText/markdown.js
@@ -2,6 +2,7 @@ import MarkdownIt from 'markdown-it';
 
 
 const md = new MarkdownIt({
+	html: true,
 	linkify: true,
 	typographer: true,
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5134,7 +5134,7 @@ dom-helpers@^3.4.0:
   dependencies:
     "@babel/runtime" "^7.1.2"
 
-dom-serializer@0:
+dom-serializer@0, dom-serializer@^0.2.1:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.2.2.tgz#1afb81f533717175d478655debc5e332d9f9bb51"
   integrity sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==
@@ -5183,6 +5183,13 @@ domhandler@^2.3.0:
   dependencies:
     domelementtype "1"
 
+domhandler@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-3.0.0.tgz#51cd13efca31da95bbb0c5bee3a48300e333b3e9"
+  integrity sha512-eKLdI5v9m67kbXQbJSNn1zjh0SDzvzWVWtX+qEI3eMjZw8daH9k8rlj1FZY9memPwjiskQFbe7vHVVJIAqoEhw==
+  dependencies:
+    domelementtype "^2.0.1"
+
 domutils@1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
@@ -5198,6 +5205,15 @@ domutils@^1.5.1, domutils@^1.7.0:
   dependencies:
     dom-serializer "0"
     domelementtype "1"
+
+domutils@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.1.0.tgz#7ade3201af43703fde154952e3a868eb4b635f16"
+  integrity sha512-CD9M0Dm1iaHfQ1R/TI+z3/JWp/pgub0j4jIQKH89ARR4ATAV2nbaOQS5XxU9maJP5jHaPdDDQSEHuE2UmpUTKg==
+  dependencies:
+    dom-serializer "^0.2.1"
+    domelementtype "^2.0.1"
+    domhandler "^3.0.0"
 
 dot-prop@^4.1.0, dot-prop@^4.1.1:
   version "4.2.0"
@@ -7224,6 +7240,16 @@ htmlparser2@^3.10.0, htmlparser2@^3.3.0:
     entities "^1.1.1"
     inherits "^2.0.1"
     readable-stream "^3.1.1"
+
+htmlparser2@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-4.1.0.tgz#9a4ef161f2e4625ebf7dfbe6c0a2f52d18a59e78"
+  integrity sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^3.0.0"
+    domutils "^2.0.0"
+    entities "^2.0.0"
 
 http-cache-semantics@3.8.1:
   version "3.8.1"
@@ -10761,6 +10787,11 @@ parse-repo@^1.0.4:
   resolved "https://registry.yarnpkg.com/parse-repo/-/parse-repo-1.0.4.tgz#74b91d2cb8675d11b99976a0065f6ce17fa1bcc8"
   integrity sha1-dLkdLLhnXRG5mXagBl9s4X+hvMg=
 
+parse-srcset@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/parse-srcset/-/parse-srcset-1.0.2.tgz#f2bd221f6cc970a938d88556abc589caaaa2bde1"
+  integrity sha1-8r0iH2zJcKk42IVWq8WJyqqiveE=
+
 parse-url@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/parse-url/-/parse-url-3.0.2.tgz#602787a7063a795d72b8673197505e72f60610be"
@@ -11517,6 +11548,15 @@ postcss@^7.0.0, postcss@^7.0.14, postcss@^7.0.16, postcss@^7.0.17, postcss@^7.0.
   version "7.0.21"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.21.tgz#06bb07824c19c2021c5d056d5b10c35b989f7e17"
   integrity sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==
+  dependencies:
+    chalk "^2.4.2"
+    source-map "^0.6.1"
+    supports-color "^6.1.0"
+
+postcss@^7.0.27:
+  version "7.0.32"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.32.tgz#4310d6ee347053da3433db2be492883d62cec59d"
+  integrity sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==
   dependencies:
     chalk "^2.4.2"
     source-map "^0.6.1"
@@ -13007,6 +13047,16 @@ sane@^4.0.3:
     micromatch "^3.1.4"
     minimist "^1.1.1"
     walker "~1.0.5"
+
+sanitize-html@^1.27.2:
+  version "1.27.2"
+  resolved "https://registry.yarnpkg.com/sanitize-html/-/sanitize-html-1.27.2.tgz#08c0cee76e594c677ab1c466594f72cb1142f399"
+  integrity sha512-REZETvhFFChM3zyQS8XoR02j5U56HtyQkxsc8cb5HEi3XU0AAX9TuKvWe3ESR0F0IA81ZghA+5YpJg8C35AFyQ==
+  dependencies:
+    htmlparser2 "^4.1.0"
+    lodash "^4.17.15"
+    parse-srcset "^1.0.2"
+    postcss "^7.0.27"
 
 sass-graph@^2.2.4:
   version "2.2.4"


### PR DESCRIPTION
Closes https://github.com/WideChat/Rocket.Chat.Livechat/issues/7

As per https://markdown-it.github.io/markdown-it/#MarkdownIt.new if we enable html, it can lead to XSS. So we need to add external sanitizer to protect from XSS. 

So only `<a>` tab is allowed for now. We can define which tags to allow and also which attributes.