### PR TITLE
Add Support To Skip Registration Form on Specified Domain

### DIFF
--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -20,7 +20,7 @@ export const loadConfig = async () => {
 		resources: { sound: src = null } = {},
 		queueInfo,
 		...config
-	} = await Livechat.config({ token });
+	} = await Livechat.config({ token, url: window.location.href });
 
 	await store.setState({
 		config,


### PR DESCRIPTION
Closes https://github.com/WideChat/Rocket.Chat.Livechat/issues/10

RC Server PR : https://github.com/WideChat/Rocket.Chat/pull/381

Adding only domain name skips registration for all paths with that domain
i.e. if `www.google.com` it will skip for `www.google.com/a`,`www.google.com/b`, `www.google.com/*`
Adding specific path like `www.google.com/a` will only skip registration on that path not others

To test

1. Go to `Admin Setting -> Omnichannel -> LiveChat`
2. Turn on Registration page
3. Add `localhost` in domain list
4. try `localhost/a`,`localhost/b` in livechat (It will not show registration page for all paths)
5. add only `localhost/a` in domain list
6. try `localhost/a`(Will not show registration page), `localhost/b` (will show registration page)